### PR TITLE
remove reference to conference in Vanuatu

### DIFF
--- a/_includes/about.html
+++ b/_includes/about.html
@@ -4,7 +4,7 @@
         <div class="col8 clearfix space-bottom2 contain">
           <div class="col10 margin2r space-bottom2">
             <h1 class="space-bottom2">FOSS4G SotM Oceania 2020</h1>
-      	    <p> <a href="https://www.picgisrs.org/conference-venue/" rel="noopener noreferrer" target="_blank">Supporting the Pacific GIS/RS Conference in Vanuatu 2020</a> </p>
+      	    <!--<p> <a href="https://www.picgisrs.org/conference-venue/" rel="noopener noreferrer" target="_blank">Supporting the Pacific GIS/RS Conference in Vanuatu 2020</a> </p>--!>
 	    <p> <h2>Conference Content:</h2> <a href="https://macwright.com/about/" rel="noopener noreferrer" target="_blank">Tom MacWright</a> </p>
             <!--<p> <h2>Conference Platform:</h2> <a href="http://maptimeoceania.slack.com/" rel="noopener noreferrer" target="_blank">Slack Platform - foss4g-sotm-oceania channel</a> </p>--!>	    
             <p> <h2>FOSS4G UK:</h2> <a href="https://wiki.osgeo.org/wiki/FOSS4GUK_2020_Online_-_Lessons_Learnt" rel="noopener noreferrer" target="_blank">Lessons Learned</a> </p>


### PR DESCRIPTION
It's delayed indefinitely. Hopefully they get to do it, but I can't see any plans.